### PR TITLE
Force a rebuild. The previous PR did not trigger a build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - make
     - groff
   host:
-    - openssl {{ openssl }}
+    - openssl 3.0.8
     - cyrus-sasl 2.1.28
   run:
     - openssl 3.*


### PR DESCRIPTION
https://github.com/AnacondaRecipes/openldap-feedstock/pull/11 was merged with "skip ci"